### PR TITLE
Allow custom thread init in AsyncIterator

### DIFF
--- a/AsyncIterator.lua
+++ b/AsyncIterator.lua
@@ -5,13 +5,15 @@
 local dl = require 'dataload._env'
 local AsyncIterator, parent = torch.class('dl.AsyncIterator', 'dl.DataLoader', dl)
 
-function AsyncIterator:__init(dataset, nthread, verbose, serialmode)
+function AsyncIterator:__init(dataset, nthread, verbose, serialmode, threadInit)
    self.dataset = dataset
    assert(torch.isTypeOf(self.dataset, "dl.DataLoader"))
    self.nthread = nthread or 2
    self.verbose = verbose == 'nil' and true or verbose
    self.serialmode = serialmode or 'ascii'
    assert(self.serialmode == "ascii" or self.serialmode == "binary","Serial mode can only be acsii or binary")
+   threadInit = threadInit or function() end
+   assert(torch.type(threadInit) == 'function')
 
    -- reset that shouldn't be shared by threads
    self.dataset:reset()
@@ -33,6 +35,7 @@ function AsyncIterator:__init(dataset, nthread, verbose, serialmode)
       function()
          dl = require 'dataload'
       end,
+      threadInit,
       function(idx)
          local success, err = pcall(function()
             t = {}


### PR DESCRIPTION
Currently it isn't possible to use custom dataloaders with AsyncIterator unless they are part of the dataload module itself. The main problem is that there is currently no way to `require` the Lua modules containing the custom dataloaders in AsyncIterator's threads.

This PR introduces an additional constructor argument to AsyncIterator which allows the user to pass in a custom thread initialization function.

For example, let's say I have my own dataloader called NswDives. I can now wrap it with an AsyncIterator as follows:

```lua
require('diving.NswDives')
dataloader = dl.NswDives('/data/nsw-dives/')
dataloader = dl.AsyncIterator(dataloader, 2, nil, nil, function()
  require('diving.NswDives')
end)
```

For reference, omitting the custom thread init functions results in the following error:

```
FATAL THREAD PANIC: (read) /root/torch/install/share/lua/5.1/torch/File.lua:343: unknown Torch class <dl.NswDives>
```